### PR TITLE
#28 fix: warm preview TLS certs before announcing the preview running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versions follow [semantic versioning](https://semver.org/) (minor for new
 functionality, patch for fixes and internal changes).
 
+## [1.1.3] - 2026-06-12
+
+### Fixed
+
+- The first visit to a brand-new project's preview could hit the browser's
+  "connection is not private" warning: the preview was announced as running
+  before its subdomain certificate existed, because certificates are issued
+  on demand at the first visit. The preview now requests its own public URL
+  once during startup, so the certificate is ready before the user ever
+  clicks the link. A slow certificate authority degrades gracefully back to
+  the old behavior instead of blocking a working preview.
+
 ## [1.1.2] - 2026-06-12
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.5)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -558,7 +558,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.24.5) sha256=36b677448524d279b470469aabd5dff4a980e3fa4931a0df68da4a500eb1b6c4
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef

--- a/lib/preview/preview_manager.rb
+++ b/lib/preview/preview_manager.rb
@@ -10,6 +10,9 @@ module Preview
     BUILD_TIMEOUT_SECONDS  = 8 * 60
     HEALTH_TIMEOUT_SECONDS = 60
     HEALTH_INTERVAL_SECONDS = 1
+    # Let's Encrypt issuance for a fresh preview host usually lands in
+    # single-digit seconds; 90 covers a slow ACME round-trip with margin.
+    TLS_WARM_TIMEOUT_SECONDS = 90
     ERROR_TRUNCATE = 2_000
 
     Result = Struct.new(:ok, :stdout, :stderr, :exit_code, keyword_init: true)
@@ -19,10 +22,12 @@ module Preview
     # dropped Object#stub, so per-instance overrides are the pattern).
     def initialize(runner: SystemRunner.new,
                    health_timeout: HEALTH_TIMEOUT_SECONDS,
-                   health_interval: HEALTH_INTERVAL_SECONDS)
-      @runner          = runner
-      @health_timeout  = health_timeout
-      @health_interval = health_interval
+                   health_interval: HEALTH_INTERVAL_SECONDS,
+                   tls_warm_timeout: TLS_WARM_TIMEOUT_SECONDS)
+      @runner           = runner
+      @health_timeout   = health_timeout
+      @health_interval  = health_interval
+      @tls_warm_timeout = tls_warm_timeout
     end
 
     # Idempotent. If a preview exists for this project, stop it first.
@@ -44,7 +49,10 @@ module Preview
       project.update!(preview_container_id: container_id)
 
       health_check!(project)
-      register_with_proxy!(project) if Preview::Config.remote?
+      if Preview::Config.remote?
+        register_with_proxy!(project)
+        wait_for_public_tls!(project)
+      end
 
       project.update!(preview_state: :running)
       ActiveSupport::Notifications.instrument(
@@ -292,11 +300,50 @@ module Preview
         "docker", "exec", "kamal-proxy",
         "kamal-proxy", "deploy", "preview-#{project.id}",
         "--target", "#{ip}:3000",
-        "--host", "#{project.id}.preview.#{Preview::Config.domain}",
+        "--host", public_preview_host(project),
         "--tls",
         capture: true
       )
       raise "kamal-proxy deploy failed: #{result.stderr}" unless result.ok
+    end
+
+    # kamal-proxy obtains the Let's Encrypt cert for a brand-new preview
+    # host on demand, triggered by the first TLS handshake for that
+    # hostname — without this wait, the user's first visit IS the trigger
+    # and lands on the proxy's self-signed fallback ("connection is not
+    # private") for the seconds the issuance takes (issue #28). Curl
+    # WITHOUT -k, so success requires a cert a browser would trust; certs
+    # persist in kamal-proxy, so restarts pass on the first probe.
+    #
+    # Non-fatal on timeout: the preview works either way, the user just
+    # risks the one-time cert interstitial — never fail a working preview
+    # over the warm-up (e.g. if the generator container can't hairpin to
+    # the host's public IP).
+    def wait_for_public_tls!(project)
+      deadline = Time.current + @tls_warm_timeout
+      until public_tls_ok?(project)
+        if Time.current > deadline
+          Rails.logger.warn(
+            "[PreviewManager] no browser-trustable cert on " \
+            "#{public_preview_host(project)} after #{@tls_warm_timeout}s — " \
+            "first visit may hit the TLS interstitial"
+          )
+          return
+        end
+        sleep @health_interval
+      end
+    end
+
+    def public_tls_ok?(project)
+      @runner.run(
+        "curl", "-fsS", "-o", "/dev/null", "-m", "5",
+        "https://#{public_preview_host(project)}/up",
+        capture: true
+      ).ok
+    end
+
+    def public_preview_host(project)
+      "#{project.id}.preview.#{Preview::Config.domain}"
     end
 
     def container_ip(container_name)

--- a/lib/preview/preview_manager.rb
+++ b/lib/preview/preview_manager.rb
@@ -321,7 +321,8 @@ module Preview
     # the host's public IP).
     def wait_for_public_tls!(project)
       deadline = Time.current + @tls_warm_timeout
-      until public_tls_ok?(project)
+      loop do
+        return if public_tls_ok?(project)
         if Time.current > deadline
           Rails.logger.warn(
             "[PreviewManager] no browser-trustable cert on " \

--- a/test/lib/preview/preview_manager_test.rb
+++ b/test/lib/preview/preview_manager_test.rb
@@ -321,6 +321,58 @@ class Preview::PreviewManagerTest < ActiveSupport::TestCase
     assert @runner.called?("docker", "exec", "kamal-proxy", "kamal-proxy", "deploy", "preview-#{@project.id}")
   end
 
+  test "start (remote): warms the public TLS endpoint after proxy registration, without -k" do
+    @runner.script("docker", "inspect", returns: Result.new(
+      ok: true, stdout: "172.99.0.5\n", stderr: "", exit_code: 0
+    ))
+    @runner.script("docker", "exec", returns: Result.new(
+      ok: true, stdout: "", stderr: "", exit_code: 0
+    ))
+
+    with_remote do
+      @manager.start(@project)
+    end
+
+    warm = @runner.calls.find { |c| c[:cmd].first == "curl" && c[:cmd].last.start_with?("https://") }
+    assert warm, "start must probe the public https URL so the cert is issued before the user's first visit"
+    assert_equal "https://#{@project.id}.preview.hifumi.dev/up", warm[:cmd].last
+    refute_includes warm[:cmd], "-k", "the probe must only pass on a browser-trustable cert"
+
+    deploy_idx = @runner.calls.index { |c| c[:cmd].include?("deploy") }
+    warm_idx   = @runner.calls.index(warm)
+    assert deploy_idx < warm_idx, "the warm probe must run after kamal-proxy registration"
+  end
+
+  test "start (remote): TLS warm timeout is non-fatal — preview still reaches running" do
+    @runner.script("docker", "inspect", returns: Result.new(
+      ok: true, stdout: "172.99.0.5\n", stderr: "", exit_code: 0
+    ))
+    @runner.script("docker", "exec", returns: Result.new(
+      ok: true, stdout: "", stderr: "", exit_code: 0
+    ))
+    # Host-side curl (the TLS probe) never verifies; in-container health
+    # checks use the `docker exec` prefix, so they stay green.
+    @runner.script("curl", returns: Result.new(ok: false, stdout: "", stderr: "SSL", exit_code: 60))
+
+    manager = Preview::PreviewManager.new(
+      runner: @runner,
+      health_timeout: 0.05, health_interval: 0.01, tls_warm_timeout: 0.05
+    )
+    with_remote do
+      manager.start(@project)
+    end
+
+    assert_equal "running", @project.reload.preview_state,
+      "a preview that works must never be failed over the cert warm-up"
+  end
+
+  test "start (dev): never probes a public https URL" do
+    @manager.start(@project)
+
+    refute @runner.calls.any? { |c| c[:cmd].any? { |a| a.start_with?("https://") } },
+      "local previews have no TLS endpoint to warm"
+  end
+
   test "start (dev): no kamal-proxy commands invoked" do
     @manager.start(@project)
 

--- a/test/lib/preview/preview_manager_test.rb
+++ b/test/lib/preview/preview_manager_test.rb
@@ -321,13 +321,23 @@ class Preview::PreviewManagerTest < ActiveSupport::TestCase
     assert @runner.called?("docker", "exec", "kamal-proxy", "kamal-proxy", "deploy", "preview-#{@project.id}")
   end
 
-  test "start (remote): warms the public TLS endpoint after proxy registration, without -k" do
+  test "start (remote): warms the public TLS endpoint after proxy registration and before announcing ready, without -k" do
     @runner.script("docker", "inspect", returns: Result.new(
       ok: true, stdout: "172.99.0.5\n", stderr: "", exit_code: 0
     ))
     @runner.script("docker", "exec", returns: Result.new(
       ok: true, stdout: "", stderr: "", exit_code: 0
     ))
+
+    # The whole point of the fix: the cert must be warm before the preview is
+    # announced ready. `preview.ready` fires right after the :running flip, so
+    # capturing whether the https probe has run by then locks the invariant a
+    # future reorder (warm moved below the running flip) would silently break.
+    warm_done_before_ready = nil
+    sub = ActiveSupport::Notifications.subscribe("preview.ready") do
+      warm_done_before_ready =
+        @runner.calls.any? { |c| c[:cmd].first == "curl" && c[:cmd].last.start_with?("https://") }
+    end
 
     with_remote do
       @manager.start(@project)
@@ -341,6 +351,10 @@ class Preview::PreviewManagerTest < ActiveSupport::TestCase
     deploy_idx = @runner.calls.index { |c| c[:cmd].include?("deploy") }
     warm_idx   = @runner.calls.index(warm)
     assert deploy_idx < warm_idx, "the warm probe must run after kamal-proxy registration"
+
+    assert warm_done_before_ready, "the cert must be warmed before the preview is announced ready"
+  ensure
+    ActiveSupport::Notifications.unsubscribe(sub) if sub
   end
 
   test "start (remote): TLS warm timeout is non-fatal — preview still reaches running" do


### PR DESCRIPTION
Fixes #28 — the first visit to a new project's preview hit the browser's "connection is not private" interstitial (reported on project 27; self-resolved minutes later once Let's Encrypt issued the cert).

## Root cause

`register_with_proxy!` registers each preview host with kamal-proxy as `--tls`, and kamal-proxy obtains per-host Let's Encrypt certificates **on demand — triggered by the first TLS handshake** for the hostname. The readiness check (`curl_ok?`) probes `/up` inside the container only, so the UI flipped to "running" while no certificate existed; the user's first click was the issuance trigger and landed on the proxy's self-signed fallback. Bites exactly once per project (certs persist and auto-renew) — but that once is the user's first impression of their generated app.

## Fix

After proxy registration and before `preview_state: :running`, `wait_for_public_tls!` polls `https://<id>.preview.<domain>/up` — curl **without** `-k`, so the probe only passes on a browser-trustable cert — mirroring the existing `health_check!` loop (same injectable-timeout pattern, new `TLS_WARM_TIMEOUT_SECONDS = 90`).

**Non-fatal on timeout:** if the public URL can't be verified from the generator container (slow ACME, hairpin-NAT quirks), it logs a warning and continues — a working preview is never failed over the warm-up; worst case is exactly the old behavior. `register_with_proxy!` also now reuses the extracted `public_preview_host`.

Alternatives rejected (recorded in #28): wildcard `*.preview` cert needs DNS-01, which kamal-proxy's autocert doesn't support (would mean replacing the proxy); pre-issuing at project creation adds lifecycle bookkeeping for no benefit.

## Test plan

- New tests: remote start probes the public https URL after proxy registration (asserts the exact URL, no `-k`, and ordering); warm timeout is non-fatal (preview still reaches running); dev start never probes an https URL. Full suite green (515 runs).
- After deploy: create a fresh project, start its preview, and click the URL immediately — no interstitial. `kamal-proxy` logs should show cert issuance during the start spinner, not at first visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)