### PR TITLE
Pre-issued wildcard TLS for previews + cookie/header hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ functionality, patch for fixes and internal changes).
   a slightly slow clock could see on a seconds-old certificate, and removes the
   first-visit issuance wait. See `docs/05-runbooks/02-preview-wildcard-tls.md`.
 
+### Changed
+
+- Hardened the generator's cookies and headers now that untrusted, user-built
+  preview apps share the `hifumi.dev` parent domain: the production session
+  cookie uses the `__Host-` prefix (un-shadowable by a preview subdomain),
+  cookies are marked `Secure` (`force_ssl` + `assume_ssl`), the remember-me
+  cookie is `Secure`/`SameSite=Lax`, and every response advertises
+  `Origin-Agent-Cluster: ?1`. Existing sessions are invalidated once on deploy
+  (the session cookie is renamed), so users will need to sign in again.
+
 ## [1.1.3] - 2026-06-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versions follow [semantic versioning](https://semver.org/) (minor for new
 functionality, patch for fixes and internal changes).
 
+## [1.2.0] - 2026-06-16
+
+### Added
+
+- Previews can now be served by a pre-issued wildcard `*.preview.hifumi.dev`
+  certificate instead of a brand-new per-host certificate minted on first
+  visit. Set `PREVIEW_TLS_CERTIFICATE_PATH` and `PREVIEW_TLS_PRIVATE_KEY_PATH`
+  (paths inside the kamal-proxy container) to switch over; unset keeps the
+  previous on-demand behavior. A long-lived wildcard certificate sidesteps the
+  "connection is not private" / certificate-transparency warning a visitor with
+  a slightly slow clock could see on a seconds-old certificate, and removes the
+  first-visit issuance wait. See `docs/05-runbooks/02-preview-wildcard-tls.md`.
+
 ## [1.1.3] - 2026-06-12
 
 ### Fixed

--- a/app/lib/preview/config.rb
+++ b/app/lib/preview/config.rb
@@ -13,5 +13,23 @@ module Preview
     def port_offset
       Rails.configuration.preview.port_offset
     end
+
+    # Path (as seen INSIDE the kamal-proxy container) to a pre-issued wildcard
+    # `*.preview.<domain>` certificate and its private key. When both are set,
+    # preview routes are registered against this static cert instead of per-host
+    # on-demand Let's Encrypt — so every preview presents an already-warm,
+    # long-settled cert (no first-visit issuance window). See
+    # docs/05-runbooks/02-preview-wildcard-tls.md.
+    def tls_certificate_path
+      Rails.configuration.preview.tls_certificate_path
+    end
+
+    def tls_private_key_path
+      Rails.configuration.preview.tls_private_key_path
+    end
+
+    def wildcard_tls?
+      tls_certificate_path.present? && tls_private_key_path.present?
+    end
   end
 end

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -20,6 +20,12 @@ env:
   clear:
     SOLID_QUEUE_IN_PUMA: true
     PREVIEW_DOMAIN: hifumi.dev
+    # Pre-issued wildcard cert for *.preview.hifumi.dev. Paths are as seen INSIDE
+    # the kamal-proxy container. Uncomment both ONLY after the cert is issued via
+    # DNS-01 and mounted into kamal-proxy (see docs/05-runbooks/02-preview-wildcard-tls.md).
+    # Until set, previews fall back to per-host on-demand Let's Encrypt.
+    # PREVIEW_TLS_CERTIFICATE_PATH: /home/kamal-proxy/.config/kamal-proxy/preview-tls/wildcard.crt
+    # PREVIEW_TLS_PRIVATE_KEY_PATH: /home/kamal-proxy/.config/kamal-proxy/preview-tls/wildcard.key
     HIFUMI_DEV_WORKSPACE_ROOT: /var/lib/hifumi-dev/workspaces
     # Image the codegen agent runs inside, per revision, as a throwaway
     # single-tenant container (Roast::Sandbox). Must be the same

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,14 +24,21 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  # Assume all access to the app is happening through a SSL-terminating reverse
+  # proxy (kamal-proxy terminates TLS and forwards plain HTTP on the internal
+  # network). This makes `request.ssl?` true, so the force_ssl redirect below
+  # never fires for proxied traffic — including kamal-proxy's own plain-HTTP
+  # `/up` healthcheck, which must keep returning 200 rather than a 301.
+  config.assume_ssl = true
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use
+  # secure cookies. Secure cookies are also a precondition for the `__Host-`
+  # session cookie (see config/initializers/session_store.rb).
+  config.force_ssl = true
 
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # Skip http-to-https redirect for the default health check endpoint (belt and
+  # braces alongside assume_ssl).
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -177,7 +177,13 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  #
+  # Mark the remember-me cookie Secure + SameSite=Lax in production. Devise hard-
+  # codes the cookie name (`remember_user_token`), so it cannot carry the
+  # `__Host-` prefix the session cookie uses — Secure + Lax is the available
+  # hardening here. Plain in dev (http://localhost can't send Secure cookies).
+  config.rememberable_options =
+    Rails.env.production? ? { secure: true, same_site: :lax } : { same_site: :lax }
 
   # ==> Configuration for :validatable
   # Range for password length.

--- a/config/initializers/preview_config.rb
+++ b/config/initializers/preview_config.rb
@@ -1,3 +1,9 @@
 Rails.application.config.preview = ActiveSupport::OrderedOptions.new
 Rails.application.config.preview.domain = ENV["PREVIEW_DOMAIN"]   # e.g. "hifumi.dev" in prod; nil in dev
 Rails.application.config.preview.port_offset = 3000               # dev: localhost:#{3000 + project.id}
+
+# Static wildcard cert for preview hosts (paths as seen inside the kamal-proxy
+# container). Both unset = per-host on-demand Let's Encrypt (the default). Set
+# both to switch every preview onto a pre-issued `*.preview.<domain>` cert.
+Rails.application.config.preview.tls_certificate_path = ENV["PREVIEW_TLS_CERTIFICATE_PATH"]
+Rails.application.config.preview.tls_private_key_path = ENV["PREVIEW_TLS_PRIVATE_KEY_PATH"]

--- a/config/initializers/security_headers.rb
+++ b/config/initializers/security_headers.rb
@@ -1,0 +1,16 @@
+# Opt every response into an origin-keyed agent cluster.
+#
+# `Origin-Agent-Cluster: ?1` disables the legacy `document.domain` setter for the
+# origin, so a page on the generator (hifumi.dev) and a page on an untrusted
+# preview (<id>.preview.hifumi.dev) can never opt into the same agent cluster and
+# relax the same-origin policy by both setting `document.domain` to the shared
+# parent. Sent in every environment (harmless where there are no subdomains).
+#
+# Mutate ActionDispatch::Response.default_headers directly: by the time
+# config/initializers run, the `action_dispatch.configure` railtie has already
+# copied config.action_dispatch.default_headers into the response class, so
+# editing the config here would be a no-op.
+ActionDispatch::Response.default_headers =
+  ActionDispatch::Response.default_headers.merge(
+    "Origin-Agent-Cluster" => "?1"
+  )

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -20,7 +20,8 @@ if Rails.env.production?
   Rails.application.config.session_store :cookie_store,
     key: "__Host-hifumi_dev_session",
     secure: true,
-    same_site: :lax
+    same_site: :lax,
+    path: "/" # the __Host- prefix mandates Path=/ (also the cookie_store default)
 else
   Rails.application.config.session_store :cookie_store,
     key: "_hifumi_dev_session",

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,28 @@
+# Session cookie hardening (multi-tenant isolation).
+#
+# In production the generator shares its registrable domain (hifumi.dev) with the
+# untrusted, user-built preview apps served at <id>.preview.hifumi.dev. A preview
+# runs arbitrary HTML/JS and can set a cookie scoped to `Domain=hifumi.dev`, which
+# the browser would deliver to the generator — letting a malicious preview shadow
+# ("toss") the generator's own session cookie onto a victim (session fixation /
+# login CSRF).
+#
+# The `__Host-` cookie-name prefix closes this: the browser REJECTS any
+# `__Host-`-named cookie that carries a Domain attribute (or a non-"/" Path, or no
+# Secure flag). A subdomain therefore cannot set a `__Host-`-named cookie for the
+# parent, so the generator's session cookie becomes un-shadowable from any preview.
+#
+# `__Host-` mandates Secure, so it only works over HTTPS. Dev runs on
+# http://localhost where a Secure cookie is never sent, so keep the plain
+# (current) cookie name there — switching only production also avoids changing the
+# dev cookie name.
+if Rails.env.production?
+  Rails.application.config.session_store :cookie_store,
+    key: "__Host-hifumi_dev_session",
+    secure: true,
+    same_site: :lax
+else
+  Rails.application.config.session_store :cookie_store,
+    key: "_hifumi_dev_session",
+    same_site: :lax
+end

--- a/docs/05-runbooks/02-preview-wildcard-tls.md
+++ b/docs/05-runbooks/02-preview-wildcard-tls.md
@@ -1,0 +1,122 @@
+# Runbook 02 — Pre-issued wildcard TLS for previews
+
+Switch preview hosts from **per-host on-demand Let's Encrypt** (a brand-new cert
+issued the first time each `<id>.preview.hifumi.dev` is hit) to a **single
+pre-issued wildcard `*.preview.hifumi.dev` cert** served statically by
+kamal-proxy.
+
+## Why
+
+On-demand issuance mints a fresh cert per preview whose SCT timestamps are
+seconds old. Any visitor whose clock is even slightly behind Chrome's 60-second
+SCT future-grace hits `NET::ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` for the first
+minutes of the cert's life (diagnosed in
+`thoughts/shared/research/2026-06-13/28-preview-tls-warmup-not-effective.md`). A
+wildcard cert is issued once and is hours/days old by the time anyone visits a
+preview, so its SCTs are long-settled and accepted regardless of small client
+clock skew. It also removes per-host LE rate-limit exposure and first-visit
+issuance latency, and makes `wait_for_public_tls!` unnecessary.
+
+The code already supports this (no deploy of code needed to keep today's
+behavior): when **both** `PREVIEW_TLS_CERTIFICATE_PATH` and
+`PREVIEW_TLS_PRIVATE_KEY_PATH` are set, `PreviewManager#register_with_proxy!`
+passes `--tls-certificate-path/--tls-private-key-path` to kamal-proxy and skips
+the warm-up. Unset (the default) = per-host on-demand `--tls`, unchanged.
+
+## Prerequisites
+
+- DNS for `hifumi.dev` is hosted at **GoDaddy** (`domaincontrol.com` nameservers).
+  Wildcard certs can only be validated with **DNS-01**, so you need GoDaddy API
+  credentials (Key + Secret) with edit rights on the zone.
+  - ⚠️ GoDaddy gates its production API: at times it has required the account to
+    hold ≥10 domains (or a specific plan). If the API is unavailable, either move
+    `hifumi.dev` DNS to a provider with an open API (Cloudflare, Route53,
+    deSEC), or issue the cert manually with a one-off `--manual` DNS-01 TXT
+    record. The rest of this runbook is provider-agnostic past the issuance step.
+- Host access to `77.42.95.154` and the running `kamal-proxy` container.
+
+## 1. Issue the wildcard via DNS-01
+
+Using [`lego`](https://go-acme.github.io/lego/) on the host (or any machine with
+the DNS creds):
+
+```bash
+GODADDY_API_KEY=...    \
+GODADDY_API_SECRET=... \
+lego --accept-tos \
+     --email ops@hifumi.dev \
+     --dns godaddy \
+     --domains '*.preview.hifumi.dev' \
+     run
+# → ./.lego/certificates/_.preview.hifumi.dev.crt  (fullchain)
+#   ./.lego/certificates/_.preview.hifumi.dev.key  (private key)
+```
+
+`acme.sh` equivalent: `acme.sh --issue --dns dns_gd -d '*.preview.hifumi.dev'`
+(reads `GD_Key` / `GD_Secret`).
+
+Keep the private key off the repo and off the generator image — it authenticates
+**every** preview subdomain. Store it only on the host, mode `600`.
+
+## 2. Make the cert visible inside the kamal-proxy container
+
+kamal-proxy resolves `--tls-certificate-path` **inside its own container**, so the
+files must exist there. Two options:
+
+- **Option A — bind-mount (durable, preferred).** Put the cert on the host (e.g.
+  `/var/lib/hifumi-dev/preview-tls/wildcard.{crt,key}`) and boot kamal-proxy with
+  that directory mounted, then reference the in-container path. Customizing the
+  Kamal-managed proxy's volumes is not a stock `deploy.yml` field, so this is a
+  manual `kamal proxy` boot adjustment — verify the resulting in-container path.
+- **Option B — copy into the container (simple, re-copy on proxy reboot).**
+
+  ```bash
+  docker exec kamal-proxy mkdir -p /home/kamal-proxy/.config/kamal-proxy/preview-tls
+  docker cp wildcard.crt kamal-proxy:/home/kamal-proxy/.config/kamal-proxy/preview-tls/wildcard.crt
+  docker cp wildcard.key kamal-proxy:/home/kamal-proxy/.config/kamal-proxy/preview-tls/wildcard.key
+  ```
+
+  The `.config/kamal-proxy` dir is kamal-proxy's persistent volume, so these
+  survive proxy restarts; re-copy only after a full proxy re-create.
+
+The path you choose is what goes in the env vars below.
+
+## 3. Point the generator at the cert
+
+In `config/deploy.yml`, uncomment and set to the **in-proxy-container** paths:
+
+```yaml
+env:
+  clear:
+    PREVIEW_TLS_CERTIFICATE_PATH: /home/kamal-proxy/.config/kamal-proxy/preview-tls/wildcard.crt
+    PREVIEW_TLS_PRIVATE_KEY_PATH: /home/kamal-proxy/.config/kamal-proxy/preview-tls/wildcard.key
+```
+
+Deploy: `kamal deploy`.
+
+## 4. Verify
+
+- Start a brand-new preview. It must come up `running` with **no** `curl https://`
+  warm-up probe in the logs (warm-up is skipped under a static cert).
+- The deploy command kamal-proxy receives now carries the cert-path flags:
+  `kamal app logs | grep "tls-certificate-path"` (or inspect proxy access logs).
+- `echo | openssl s_client -connect <id>.preview.hifumi.dev:443 -servername <id>.preview.hifumi.dev | openssl x509 -noout -subject -dates`
+  → `subject=CN = *.preview.hifumi.dev`, and the `notBefore` is the wildcard's
+  issuance date (not "today").
+
+Already-running previews keep their per-host autocert certs until restarted —
+only newly-started previews pick up the wildcard. That is fine (the old certs are
+still valid); previews are reaped after 30 min, so the fleet rolls over quickly.
+
+## 5. Renewal
+
+The cert is ~90 days; renew around day 60. Re-run the `lego ... renew` (or
+`acme.sh` cron), re-place the files (step 2), then make kamal-proxy reload them:
+it reads the cert at route-deploy time, so either re-register active routes or
+restart the proxy (`kamal proxy reboot`) — a brief blip. Because previews are
+short-lived, most routes re-register naturally within 30 min anyway.
+
+## Rollback
+
+Re-comment both `PREVIEW_TLS_*` env vars in `deploy.yml` and `kamal deploy`. New
+previews fall straight back to per-host on-demand `--tls`; no other change.

--- a/docs/05-runbooks/02-preview-wildcard-tls.md
+++ b/docs/05-runbooks/02-preview-wildcard-tls.md
@@ -10,8 +10,9 @@ kamal-proxy.
 On-demand issuance mints a fresh cert per preview whose SCT timestamps are
 seconds old. Any visitor whose clock is even slightly behind Chrome's 60-second
 SCT future-grace hits `NET::ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` for the first
-minutes of the cert's life (diagnosed in
-`thoughts/shared/research/2026-06-13/28-preview-tls-warmup-not-effective.md`). A
+minutes of the cert's life — the cert is valid, but a client clock running behind
+the fresh SCT timestamps reads them as future-dated (post-incident diagnosis of
+the 28.preview.hifumi.dev report). A
 wildcard cert is issued once and is hours/days old by the time anyone visits a
 preview, so its SCTs are long-settled and accepted regardless of small client
 clock skew. It also removes per-host LE rate-limit exposure and first-visit
@@ -28,8 +29,8 @@ the warm-up. Unset (the default) = per-host on-demand `--tls`, unchanged.
 - DNS for `hifumi.dev` is hosted at **GoDaddy** (`domaincontrol.com` nameservers).
   Wildcard certs can only be validated with **DNS-01**, so you need GoDaddy API
   credentials (Key + Secret) with edit rights on the zone.
-  - ⚠️ GoDaddy gates its production API: at times it has required the account to
-    hold ≥10 domains (or a specific plan). If the API is unavailable, either move
+  - ⚠️ GoDaddy gates its production API: as of 2026 it has at times required the
+    account to hold ≥10 domains (or a specific plan). If the API is unavailable, either move
     `hifumi.dev` DNS to a provider with an open API (Cloudflare, Route53,
     deSEC), or issue the cert manually with a one-off `--manual` DNS-01 TXT
     record. The rest of this runbook is provider-agnostic past the issuance step.

--- a/lib/preview/preview_manager.rb
+++ b/lib/preview/preview_manager.rb
@@ -51,7 +51,10 @@ module Preview
       health_check!(project)
       if Preview::Config.remote?
         register_with_proxy!(project)
-        wait_for_public_tls!(project)
+        # With a pre-issued wildcard cert the public endpoint is already warm
+        # (the cert exists before any preview starts), so there is no per-host
+        # issuance window to wait out — only on-demand Let's Encrypt needs it.
+        wait_for_public_tls!(project) unless Preview::Config.wildcard_tls?
       end
 
       project.update!(preview_state: :running)
@@ -296,14 +299,24 @@ module Preview
       ip = container_ip(container_name)
       raise "Could not resolve container IP for #{container_name}" if ip.blank?
 
-      result = @runner.run(
+      cmd = [
         "docker", "exec", "kamal-proxy",
         "kamal-proxy", "deploy", "preview-#{project.id}",
         "--target", "#{ip}:3000",
         "--host", public_preview_host(project),
-        "--tls",
-        capture: true
-      )
+        "--tls"
+      ]
+      # When a pre-issued wildcard cert is configured, hand kamal-proxy the static
+      # cert/key paths so it serves them instead of obtaining a per-host cert on
+      # demand. Paths are resolved inside the kamal-proxy container.
+      if Preview::Config.wildcard_tls?
+        cmd.push(
+          "--tls-certificate-path", Preview::Config.tls_certificate_path,
+          "--tls-private-key-path", Preview::Config.tls_private_key_path
+        )
+      end
+
+      result = @runner.run(*cmd, capture: true)
       raise "kamal-proxy deploy failed: #{result.stderr}" unless result.ok
     end
 

--- a/test/integration/security_headers_test.rb
+++ b/test/integration/security_headers_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class SecurityHeadersTest < ActionDispatch::IntegrationTest
+  setup do
+    cookies[:cookie_consent] = "accepted"
+  end
+
+  # Origin-Agent-Cluster: ?1 disables the legacy document.domain setter so the
+  # generator and an untrusted preview subdomain can never relax the same-origin
+  # policy to the shared parent. Asserted on a plain marketing response.
+  test "every response advertises an origin-keyed agent cluster" do
+    get root_path
+    assert_response :success
+    assert_equal "?1", response.headers["Origin-Agent-Cluster"]
+  end
+end

--- a/test/lib/preview/config_test.rb
+++ b/test/lib/preview/config_test.rb
@@ -34,9 +34,15 @@ class Preview::ConfigTest < ActiveSupport::TestCase
     assert_not Preview::Config.wildcard_tls?
   end
 
-  test "wildcard_tls? is false when only one path is set" do
+  test "wildcard_tls? is false when only the cert path is set" do
     Rails.configuration.preview.tls_certificate_path = "/proxy/certs/wildcard.crt"
     Rails.configuration.preview.tls_private_key_path = nil
+    assert_not Preview::Config.wildcard_tls?
+  end
+
+  test "wildcard_tls? is false when only the key path is set" do
+    Rails.configuration.preview.tls_certificate_path = nil
+    Rails.configuration.preview.tls_private_key_path = "/proxy/certs/wildcard.key"
     assert_not Preview::Config.wildcard_tls?
   end
 

--- a/test/lib/preview/config_test.rb
+++ b/test/lib/preview/config_test.rb
@@ -3,10 +3,14 @@ require "test_helper"
 class Preview::ConfigTest < ActiveSupport::TestCase
   setup do
     @original_domain = Rails.configuration.preview.domain
+    @original_cert   = Rails.configuration.preview.tls_certificate_path
+    @original_key    = Rails.configuration.preview.tls_private_key_path
   end
 
   teardown do
     Rails.configuration.preview.domain = @original_domain
+    Rails.configuration.preview.tls_certificate_path = @original_cert
+    Rails.configuration.preview.tls_private_key_path = @original_key
   end
 
   test "remote? is false when domain is nil" do
@@ -22,5 +26,25 @@ class Preview::ConfigTest < ActiveSupport::TestCase
 
   test "port_offset returns the configured value" do
     assert_equal 3000, Preview::Config.port_offset
+  end
+
+  test "wildcard_tls? is false when neither path is set" do
+    Rails.configuration.preview.tls_certificate_path = nil
+    Rails.configuration.preview.tls_private_key_path = nil
+    assert_not Preview::Config.wildcard_tls?
+  end
+
+  test "wildcard_tls? is false when only one path is set" do
+    Rails.configuration.preview.tls_certificate_path = "/proxy/certs/wildcard.crt"
+    Rails.configuration.preview.tls_private_key_path = nil
+    assert_not Preview::Config.wildcard_tls?
+  end
+
+  test "wildcard_tls? is true and paths are exposed when both are set" do
+    Rails.configuration.preview.tls_certificate_path = "/proxy/certs/wildcard.crt"
+    Rails.configuration.preview.tls_private_key_path = "/proxy/certs/wildcard.key"
+    assert Preview::Config.wildcard_tls?
+    assert_equal "/proxy/certs/wildcard.crt", Preview::Config.tls_certificate_path
+    assert_equal "/proxy/certs/wildcard.key", Preview::Config.tls_private_key_path
   end
 end

--- a/test/lib/preview/preview_manager_test.rb
+++ b/test/lib/preview/preview_manager_test.rb
@@ -419,6 +419,8 @@ class Preview::PreviewManagerTest < ActiveSupport::TestCase
       end
     end
 
+    assert @runner.called?("docker", "exec", "kamal-proxy", "kamal-proxy", "deploy", "preview-#{@project.id}"),
+      "the wildcard path must still register the route (skip is not start short-circuiting)"
     refute @runner.calls.any? { |c| c[:cmd].first == "curl" && c[:cmd].last.start_with?("https://") },
       "a pre-issued wildcard cert needs no warm-up — there is no per-host issuance window"
     assert_equal "running", @project.reload.preview_state

--- a/test/lib/preview/preview_manager_test.rb
+++ b/test/lib/preview/preview_manager_test.rb
@@ -387,6 +387,58 @@ class Preview::PreviewManagerTest < ActiveSupport::TestCase
       "local previews have no TLS endpoint to warm"
   end
 
+  # --- wildcard (static) cert path --------------------------------------
+
+  test "register (remote, wildcard cert): deploy passes --tls-certificate-path / --tls-private-key-path" do
+    @runner.script("docker", "inspect", returns: Result.new(
+      ok: true, stdout: "172.99.0.5\n", stderr: "", exit_code: 0
+    ))
+
+    with_remote do
+      with_wildcard_tls do
+        @manager.start(@project)
+      end
+    end
+
+    deploy = @runner.calls.find { |c| c[:cmd].include?("deploy") }
+    assert deploy, "kamal-proxy deploy was not invoked"
+    assert_includes deploy[:cmd], "--tls-certificate-path"
+    assert_includes deploy[:cmd], "/proxy/certs/wildcard.crt"
+    assert_includes deploy[:cmd], "--tls-private-key-path"
+    assert_includes deploy[:cmd], "/proxy/certs/wildcard.key"
+  end
+
+  test "start (remote, wildcard cert): skips the public https TLS warm-up (cert already warm)" do
+    @runner.script("docker", "inspect", returns: Result.new(
+      ok: true, stdout: "172.99.0.5\n", stderr: "", exit_code: 0
+    ))
+
+    with_remote do
+      with_wildcard_tls do
+        @manager.start(@project)
+      end
+    end
+
+    refute @runner.calls.any? { |c| c[:cmd].first == "curl" && c[:cmd].last.start_with?("https://") },
+      "a pre-issued wildcard cert needs no warm-up — there is no per-host issuance window"
+    assert_equal "running", @project.reload.preview_state
+  end
+
+  test "register (remote, no wildcard cert): deploy omits the static cert path flags" do
+    @runner.script("docker", "inspect", returns: Result.new(
+      ok: true, stdout: "172.99.0.5\n", stderr: "", exit_code: 0
+    ))
+
+    with_remote do
+      @manager.start(@project)
+    end
+
+    deploy = @runner.calls.find { |c| c[:cmd].include?("deploy") }
+    assert deploy
+    refute_includes deploy[:cmd], "--tls-certificate-path"
+    assert_includes deploy[:cmd], "--tls", "on-demand path still passes plain --tls"
+  end
+
   test "start (dev): no kamal-proxy commands invoked" do
     @manager.start(@project)
 
@@ -500,5 +552,16 @@ class Preview::PreviewManagerTest < ActiveSupport::TestCase
     yield
   ensure
     Rails.configuration.preview.domain = original
+  end
+
+  def with_wildcard_tls
+    orig_cert = Rails.configuration.preview.tls_certificate_path
+    orig_key  = Rails.configuration.preview.tls_private_key_path
+    Rails.configuration.preview.tls_certificate_path = "/proxy/certs/wildcard.crt"
+    Rails.configuration.preview.tls_private_key_path = "/proxy/certs/wildcard.key"
+    yield
+  ensure
+    Rails.configuration.preview.tls_certificate_path = orig_cert
+    Rails.configuration.preview.tls_private_key_path = orig_key
   end
 end


### PR DESCRIPTION
Two independent changes that came out of the `28.preview.hifumi.dev` cert investigation (see `thoughts/shared/research/2026-06-13/28-preview-tls-warmup-not-effective.md`). Split into two commits so they can be reviewed — and deployed/timed — separately.

## 1. Opt-in pre-issued wildcard TLS for previews (`d9ac746`)

kamal-proxy issues a **per-host** Let's Encrypt cert on the first TLS handshake, so every brand-new preview presents a cert whose SCT timestamps are seconds old. A visitor whose clock is behind Chrome's 60s SCT future-grace then gets `ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` until the cert ages past the skew (plus there's first-visit issuance latency).

- `PreviewManager#register_with_proxy!` passes `--tls-certificate-path/--tls-private-key-path` (and skips the public TLS warm-up) when **both** `PREVIEW_TLS_CERTIFICATE_PATH` and `PREVIEW_TLS_PRIVATE_KEY_PATH` are set.
- **Inert until the cert is provisioned** — unset keeps today's per-host on-demand `--tls`, so this is safe to merge/deploy before the wildcard exists.
- Runbook added: `docs/05-runbooks/02-preview-wildcard-tls.md` (DNS-01 issuance via GoDaddy, mounting into kamal-proxy, renewal, rollback).

**Manual follow-up (needs DNS creds + host access):** issue `*.preview.hifumi.dev` via DNS-01, mount it into kamal-proxy, then uncomment the two env vars in `deploy.yml`.

## 2. Cookie/header hardening against preview subdomains (`3b1ebef`)

Untrusted, user-built preview apps share the `hifumi.dev` registrable domain with the generator, so a preview can set `Domain=hifumi.dev` cookies that shadow the generator's session cookie (login CSRF / session fixation) and counts as same-site for `SameSite`.

- Production session cookie → `__Host-` prefix (un-shadowable from a subdomain).
- `force_ssl` + `assume_ssl` → Secure cookies; `assume_ssl` keeps the proxy's plain-HTTP `/up` healthcheck a 200, not a redirect.
- Devise remember-me cookie Secure + SameSite=Lax.
- `Origin-Agent-Cluster: ?1` on every response (disables `document.domain`).

⚠️ **Deploying this logs everyone out once** (the session cookie is renamed). `force_ssl` is a production behavior change — worth watching the first deploy's healthcheck (rollback = re-comment in `production.rb`).

## Verification
- Full suite green: **522 runs, 0 failures, 0 errors**.
- Brakeman: **no warnings**.
- New tests: static-cert flags + warm-up skip + on-demand branch (`PreviewManager`), `wildcard_tls?` (`Config`), `Origin-Agent-Cluster` header (integration).
