### PR TITLE
Stop git's background housekeeping from failing a revision

### DIFF
--- a/app/jobs/execute_instruction_job.rb
+++ b/app/jobs/execute_instruction_job.rb
@@ -72,12 +72,18 @@ class ExecuteInstructionJob < ApplicationJob
       )
       raise "bundle install failed in #{workspace}" unless ok
 
+      # maintenance.auto/gc.auto: background housekeeping writes transient lock
+      # files under .git that vanish mid-walk and ENOENT the chmod_R in
+      # relax_workspace_permissions, failing the revision. A tenant workspace is
+      # short-lived and small; it never needs to repack itself.
       ok = system(
         subprocess_env,
         "cd #{Shellwords.escape(workspace)} && " \
         "git init -q -b main && " \
         "git config user.email #{Shellwords.escape(Project::COMMIT_AUTHOR_EMAIL)} && " \
         "git config user.name #{Shellwords.escape(Project::COMMIT_AUTHOR_NAME)} && " \
+        "git config maintenance.auto false && " \
+        "git config gc.auto 0 && " \
         "git add -A && " \
         "git -c user.email=#{Shellwords.escape(Project::COMMIT_AUTHOR_EMAIL)} " \
         "-c user.name=#{Shellwords.escape(Project::COMMIT_AUTHOR_NAME)} " \
@@ -108,7 +114,13 @@ class ExecuteInstructionJob < ApplicationJob
   # already a+rw inside the tenant boundary and generated apps ship empty
   # credentials.
   def relax_workspace_permissions(workspace)
-    FileUtils.chmod_R("a+rwX", workspace)
+    # force: chmod_R stats every entry it walked, and anything git drops in
+    # between (a lock file from background housekeeping, an index refresh)
+    # raises ENOENT and aborts the whole walk — failing the revision. Workspaces
+    # created before the maintenance.auto/gc.auto config above still exist, so
+    # this is not redundant with it. Relaxation is best-effort by nature: a
+    # genuinely unchmoddable file surfaces at the next operation instead.
+    FileUtils.chmod_R("a+rwX", workspace, force: true)
     master_key_path = File.join(workspace, "config/master.key")
     File.chmod(0o644, master_key_path) if File.exist?(master_key_path)
   end

--- a/test/jobs/execute_instruction_job_test.rb
+++ b/test/jobs/execute_instruction_job_test.rb
@@ -239,6 +239,39 @@ class ExecuteInstructionJobTest < ActiveJob::TestCase
     end
   end
 
+  test "relax_workspace_permissions survives an entry that disappears mid-walk" do
+    # git's background housekeeping drops transient lock files under .git.
+    # chmod_R lists a directory, then chmods each entry it listed — so a file
+    # git removes in that window raises ENOENT and aborts the whole walk,
+    # failing the revision. Seen in CI on git 2.47. Simulated by making chmod
+    # raise for exactly that path, which is what the kernel does when the
+    # listed file is already gone.
+    Dir.mktmpdir("hifumi-dev-vanish-") do |root|
+      ws = File.join(root, "project_vanish")
+      FileUtils.mkdir_p(File.join(ws, ".git/objects"))
+      File.write(File.join(ws, ".git/objects/maintenance.lock"), "")
+      File.write(File.join(ws, "Gemfile.lock"), "GEM\n")
+
+      original = File.method(:chmod)
+      File.define_singleton_method(:chmod) do |mode, *paths|
+        if paths.any? { |path| path.to_s.end_with?("maintenance.lock") }
+          raise Errno::ENOENT, paths.first.to_s
+        end
+        original.call(mode, *paths)
+      end
+
+      begin
+        ExecuteInstructionJob.new.send(:relax_workspace_permissions, ws)
+      ensure
+        File.singleton_class.send(:remove_method, :chmod)
+        File.define_singleton_method(:chmod, original)
+      end
+
+      assert_equal 0o666, File.stat(File.join(ws, "Gemfile.lock")).mode & 0o777,
+                   "the walk must still relax the files that do exist"
+    end
+  end
+
   # --- seam shape --------------------------------------------------------
 
   test "run_roast_subprocess receives HIFUMI_DEV_* env and bin/roast workflow args" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,20 @@ TEST_WORKSPACES_ROOT = File.join(Dir.tmpdir, "hifumi-dev-test-workspaces")
 ENV["HIFUMI_DEV_WORKSPACE_ROOT"] ||=
   File.join(TEST_WORKSPACES_ROOT, "pid_#{Process.pid}")
 
+# Disable git's background housekeeping for every git subprocess a test spawns.
+# It writes transient lock files under .git (e.g. objects/maintenance.lock) that
+# vanish between a directory walk and the per-entry operation, so any test that
+# chmods or removes a tree containing a git repo can ENOENT — including
+# Dir.mktmpdir's own cleanup, which no application-side fix can reach. Seen in
+# CI (git 2.47) across unrelated tests; local git 2.44 rarely triggers it.
+# GIT_CONFIG_COUNT injects config into every child git without touching the
+# developer's global config.
+ENV["GIT_CONFIG_COUNT"] = "2"
+ENV["GIT_CONFIG_KEY_0"] = "maintenance.auto"
+ENV["GIT_CONFIG_VALUE_0"] = "false"
+ENV["GIT_CONFIG_KEY_1"] = "gc.auto"
+ENV["GIT_CONFIG_VALUE_1"] = "0"
+
 require_relative "../config/environment"
 require "rails/test_help"
 


### PR DESCRIPTION
Fixes the intermittent CI failure that is currently blocking #41. Not a test flake — a real race that also affects production.

## What's happening

```
Errno::ENOENT: .../.git/objects/maintenance.lock
  app/jobs/execute_instruction_job.rb relax_workspace_permissions
```

git 2.47 runs background maintenance automatically after commits, writing transient lock files under `.git`. `chmod_R` lists a directory and then chmods each entry it listed — anything git removes in that window raises `ENOENT` and aborts the whole walk.

**In production that fails a revision.** `relax_workspace_permissions` runs before every sandboxed roast run, on live workspaces where git commands fire constantly. Local git 2.44 rarely triggers it, which is why it has only ever shown up in CI.

## Evidence it's a race, not a bad test

- It lands in **different, unrelated tests** — `ExecuteInstructionJobTest` in one run, `Templates::PickerTest` in another.
- A **docs-only commit** flipped CI from green to red six minutes apart.
- The failing code was last touched 2026-06-12 and is untouched by #41.

## The fix, at both levels

- **Root cause** — workspaces we create set `maintenance.auto=false` and `gc.auto=0` at `git init`. A tenant workspace is short-lived and small; it never needs to repack itself, so the lock files should not exist at all.
- **Resilience** — `relax_workspace_permissions` passes `force: true`, because workspaces created before that config still exist in production and would otherwise keep racing. Relaxation is best-effort by nature: a genuinely unchmoddable file surfaces at the next operation with a clearer error than a half-finished walk.
- **Tests** — same two settings injected via `GIT_CONFIG_COUNT` in `test_helper`, reaching every git subprocess a test spawns without touching your global config. Not optional: the `Templates::PickerTest` failure was inside `Dir.mktmpdir`'s own cleanup, which no application-side fix can reach.

## The regression test

Models the exact window — `chmod` raising `ENOENT` for a path the walk had already listed, which is what the kernel does when the file is gone — and asserts the walk still relaxes the files that do exist.

Worth knowing: **my first version of this test passed with the fix reverted**, because `chmod_R` calls `File.chmod`, not `FileUtils.chmod`, so the stub never fired. It was rewritten until it genuinely reproduced. It now errors at `relax_workspace_permissions` without the `force:` change and passes with it.

## Verification

562 runs / 0 failures, rubocop, brakeman clean.

Since the bug is intermittent, CI passing once here is suggestive, not proof. The root-cause half (no lock files created at all) is the part that should make it deterministic.