### PR TITLE
Keep the image's Bundler defaults when roast strips BUNDLE_* for subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versions follow [semantic versioning](https://semver.org/) (minor for new
 functionality, patch for fixes and internal changes).
 
+## [1.5.2] - 2026-09-04
+
+### Fixed
+
+- 1.5.1 put the right gems in the image but the build steps kept
+  reinstalling them. The step runner strips every `BUNDLE_*` variable before
+  spawning the code agent and the verification commands, and that took the
+  image's `BUNDLE_PATH` and `BUNDLE_WITHOUT` with it, so Bundler looked in the
+  wrong directory and asked for the development group the image never
+  installs. The agent wrapper and the verification step now restore those two
+  variables, and the automatic `bundle install` remediation runs against the
+  project's Gemfile instead of the generator's. Verified against production
+  by reproducing the failure with the variables stripped and the pass with
+  them restored.
+
 ## [1.5.1] - 2026-09-03
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,12 @@ RUN apt-get update -qq && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
+# Bundler globals. Declared before the claude wrapper below so the wrapper
+# can quote the same values at build time (see the export it writes).
+ENV BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development"
+
 # Install the Claude Code CLI binary. Roast 1.1.0's only agent providers are
 # :claude and :pi, and the :claude provider spawns a `claude` binary via
 # Open3. bin/roast-openrouter sets ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN so
@@ -58,13 +64,22 @@ RUN useradd -m -u 1000 -s /bin/bash generator && \
     rm /root/.local/bin/claude && \
     printf '%s\n' \
       '#!/bin/sh' \
+      '# Roast spawns this binary inside Bundler.with_unbundled_env, which deletes every' \
+      '# BUNDLE_* variable, the image-level BUNDLE_PATH and BUNDLE_WITHOUT included. Without' \
+      '# them Bundler looks for gems under $GEM_HOME/gems instead of $BUNDLE_PATH/ruby/<abi>/gems' \
+      '# and every workspace command (bin/rails, bundle check) reports the whole lockfile' \
+      '# missing. Restore the image defaults for the agent and everything it runs.' \
+      > /usr/local/bin/claude && \
+    printf 'export BUNDLE_PATH="${BUNDLE_PATH:-%s}" BUNDLE_WITHOUT="${BUNDLE_WITHOUT:-%s}"\n' "$BUNDLE_PATH" "$BUNDLE_WITHOUT" \
+      >> /usr/local/bin/claude && \
+    printf '%s\n' \
       'real=/opt/claude/versions/$(ls -1 /opt/claude/versions | sort -V | tail -1)' \
       'if [ "$(id -u)" -eq 0 ]; then' \
       '  HOME=/home/generator exec runuser -p -u generator -- "$real" "$@"' \
       'else' \
       '  exec "$real" "$@"' \
       'fi' \
-      > /usr/local/bin/claude && \
+      >> /usr/local/bin/claude && \
     chmod +x /usr/local/bin/claude && \
     git config --system --add safe.directory '*' && \
     git config --system user.name 'Hifumi' && \
@@ -72,9 +87,6 @@ RUN useradd -m -u 1000 -s /bin/bash generator && \
 
 # Set production environment variables and enable jemalloc for reduced memory usage and latency.
 ENV RAILS_ENV="production" \
-    BUNDLE_DEPLOYMENT="1" \
-    BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development" \
     LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 
 # Throw-away build stage to reduce size of final image

--- a/lib/roast/auto_remediate.rb
+++ b/lib/roast/auto_remediate.rb
@@ -10,6 +10,7 @@
 # Empirical impact: a single fix-agent turn averages $0.05–$1.00 on sonnet.
 # Catching even one recipe per workflow saves that.
 require "shellwords"
+require_relative "verify_revision"
 
 module AutoRemediate
   # Each recipe: { match: Regexp, fix: ->(workspace, errors_text) { ... } }
@@ -46,8 +47,12 @@ module AutoRemediate
     applied
   end
 
-  # Single shell seam — recipes route through here so tests can stub it.
+  # Single shell seam — recipes route through here so tests can stub it. Same
+  # scrubbed env as VerifyRevision: under roast's `bundle exec` a plain system()
+  # carries BUNDLE_GEMFILE=<generator Gemfile>, so the `bundle install` recipe
+  # "completed" against the generator's already-satisfied bundle in 0.6s and
+  # fixed nothing, every revision (production, 2026-09-03).
   def self.shell(workspace, cmd)
-    system("cd #{Shellwords.escape(workspace)} && #{cmd}")
+    VerifyRevision.with_clean_bundler_env { system("cd #{Shellwords.escape(workspace)} && #{cmd}") }
   end
 end

--- a/lib/roast/verify_revision.rb
+++ b/lib/roast/verify_revision.rb
@@ -67,17 +67,25 @@ module VerifyRevision
     with_clean_bundler_env { system("cd #{workspace} && bundle show #{name} > /dev/null 2>&1") }
   end
 
-  # Roast runs under `bundle exec`, which sets BUNDLE_GEMFILE pointing at the
-  # generator's Gemfile. Subprocess `bundle check` / `bin/rails` against the
-  # workspace must NOT see that, or it'd resolve gems against the wrong
-  # bundle. The earlier hand-rolled scrubber stripped every BUNDLE_* var,
-  # which over-deleted: it also dropped BUNDLE_PATH (set globally by the
-  # Dockerfile to /usr/local/bundle) so bundler defaulted to a different
-  # lookup path and reported gems missing even after `bundle install` had
-  # populated /usr/local/bundle. Bundler's own with_unbundled_env reverts
-  # only what bundler itself set on entering the bundle, leaving Dockerfile
-  # globals intact.
-  def self.with_clean_bundler_env(&block)
-    Bundler.with_unbundled_env(&block)
+  # Roast runs under `bundle exec`, which sets BUNDLE_GEMFILE to the generator's
+  # Gemfile and RUBYOPT=-rbundler/setup. Subprocess `bundle check` / `bin/rails`
+  # against the workspace must not see those, or they resolve against the wrong
+  # bundle. Bundler.with_unbundled_env removes them — but it removes EVERY
+  # BUNDLE_* variable, the image-level ones included (this comment used to claim
+  # otherwise; production disproved it on 2026-09-03). Without BUNDLE_PATH,
+  # Bundler looks under $GEM_HOME/gems instead of $BUNDLE_PATH/ruby/<abi>/gems
+  # and reports the whole lockfile missing; without BUNDLE_WITHOUT it wants the
+  # development group the image never installs. Both are restored here from the
+  # env as it was before `bundle exec`. In dev neither is set, so nothing is
+  # added. The claude wrapper in the Dockerfile does the same for the agent,
+  # which roast spawns unbundled as well.
+  IMAGE_BUNDLER_ENV = %w[BUNDLE_PATH BUNDLE_WITHOUT].freeze
+
+  def self.with_clean_bundler_env
+    Bundler.with_unbundled_env do
+      original = Bundler.original_env
+      IMAGE_BUNDLER_ENV.each { |key| ENV[key] = original[key] if original.key?(key) }
+      yield
+    end
   end
 end

--- a/test/lib/verify_revision_test.rb
+++ b/test/lib/verify_revision_test.rb
@@ -53,15 +53,10 @@ class VerifyRevisionTest < ActiveSupport::TestCase
                  "BUNDLE_GEMFILE leaked inside the block — workspace bundle commands would resolve against the parent Gemfile"
   end
 
-  test "with_clean_bundler_env delegates to Bundler.with_unbundled_env (regression: hand-rolled scrub stripped BUNDLE_PATH)" do
-    # The earlier implementation stripped every BUNDLE_*-prefixed var, which
-    # over-deleted: it also dropped BUNDLE_PATH (set globally to
-    # /usr/local/bundle by the Dockerfile, where every bundle install
-    # deposits gems). With BUNDLE_PATH gone, subprocess `bundle check`
-    # defaulted to a different lookup path and reported gems missing even
-    # after `bundle install` had populated /usr/local/bundle.
-    # Bundler.with_unbundled_env reverts only what bundler itself set on
-    # entering the bundle, leaving Dockerfile globals intact.
+  test "with_clean_bundler_env delegates to Bundler.with_unbundled_env" do
+    # Bundler's primitive is what knows how to undo `bundle exec` (BUNDLE_GEMFILE,
+    # BUNDLE_BIN_PATH, the -rbundler/setup in RUBYOPT, the RUBYLIB entry). The
+    # hand-rolled scrubber it replaced got that list wrong once already.
     delegated = false
     original = Bundler.method(:with_unbundled_env)
     Bundler.singleton_class.define_method(:with_unbundled_env) do |&blk|
@@ -74,6 +69,37 @@ class VerifyRevisionTest < ActiveSupport::TestCase
     Bundler.singleton_class.define_method(:with_unbundled_env, &original) if original
   end
 
+  # Bundler.with_unbundled_env deletes EVERY BUNDLE_* variable, not only what
+  # `bundle exec` set. In the production image BUNDLE_PATH and BUNDLE_WITHOUT
+  # are Dockerfile globals; losing them made every workspace `bundle check`
+  # report the whole lockfile missing (2026-09-03). These pin the restore.
+
+  test "with_clean_bundler_env restores the image's BUNDLE_PATH and BUNDLE_WITHOUT while still dropping BUNDLE_GEMFILE" do
+    with_original_env_stub(
+      "BUNDLE_GEMFILE" => "/rails/Gemfile", "BUNDLE_BIN_PATH" => "/x/bundle", "RUBYOPT" => "-rbundler/setup",
+      "BUNDLE_PATH" => "/usr/local/bundle", "BUNDLE_WITHOUT" => "development", "BUNDLE_APP_CONFIG" => "/usr/local/bundle"
+    ) do
+      inside = VerifyRevision.with_clean_bundler_env { ENV.to_h.slice(*%w[BUNDLE_GEMFILE BUNDLE_BIN_PATH BUNDLE_PATH BUNDLE_WITHOUT BUNDLE_APP_CONFIG]) }
+
+      assert_equal({ "BUNDLE_PATH" => "/usr/local/bundle", "BUNDLE_WITHOUT" => "development" }, inside)
+    end
+  end
+
+  test "with_clean_bundler_env adds nothing when the original env carries no image-level Bundler vars (dev)" do
+    with_original_env_stub("BUNDLE_GEMFILE" => "/rails/Gemfile", "RUBYOPT" => "-rbundler/setup", "BUNDLE_PATH" => nil, "BUNDLE_WITHOUT" => nil) do
+      inside = VerifyRevision.with_clean_bundler_env { ENV.to_h.select { |k, _| k.start_with?("BUNDLE_") } }
+
+      assert_empty inside
+    end
+  end
+
+  test "with_clean_bundler_env leaves the parent process env untouched afterwards" do
+    before = ENV.to_h
+    VerifyRevision.with_clean_bundler_env { ENV["BUNDLE_PATH"] = "/leaked" }
+
+    assert_equal before, ENV.to_h
+  end
+
   test "with_clean_bundler_env returns the block's value and propagates exceptions" do
     assert_equal 42, VerifyRevision.with_clean_bundler_env { 42 }
 
@@ -84,6 +110,18 @@ class VerifyRevisionTest < ActiveSupport::TestCase
   end
 
   private
+
+  # Bundler.unbundled_env builds on Bundler.original_env (the env before
+  # `bundle exec`), so swapping that one method is enough to simulate the
+  # production image's env from a dev box. nil removes a key.
+  def with_original_env_stub(overrides)
+    original = Bundler.method(:original_env)
+    fake = original.call.merge(overrides).compact
+    Bundler.singleton_class.define_method(:original_env) { fake.dup }
+    yield
+  ensure
+    Bundler.singleton_class.define_method(:original_env, &original) if original
+  end
 
   # Replace VerifyRevision.perform with a stub that returns the configured
   # outcome per check. Defaults to pass for unspecified checks.


### PR DESCRIPTION
## Why

PR #45 put the skeleton's gems in the image, and `bundle check` on a workspace now passes in the generator container and in a plain `docker run --user 1000` of the sandbox image. It still failed inside every real sandbox run (project 36, 2026-09-03 22:08: all 116 gems "missing", fix agent reinstalls them, 97s and $0.07 per revision).

Cause: `Bundler.with_unbundled_env`, used by our verify step and by the roast gem when it spawns the code agent, deletes **every** `BUNDLE_*` variable, not only what `bundle exec` set. That takes the Dockerfile's `BUNDLE_PATH` and `BUNDLE_WITHOUT` with it. Without `BUNDLE_PATH`, Bundler looks under `$GEM_HOME/gems` instead of `$BUNDLE_PATH/ruby/<abi>/gems` and reports the whole lockfile missing; without `BUNDLE_WITHOUT` it wants the development group the image never installs. Reproduced on production:

| env inside the sandbox image | `bundle check` |
|---|---|
| as shipped | satisfied |
| `BUNDLE_*` stripped | every gem missing |
| only `BUNDLE_PATH` restored | web-console, bindex missing |

## What

- **Dockerfile**: the `claude` wrapper exports `BUNDLE_PATH`/`BUNDLE_WITHOUT` (image defaults, caller values win), so the agent and everything it runs resolve gems. The Bundler `ENV` block moves above the wrapper so it quotes the same values at build time.
- **`VerifyRevision.with_clean_bundler_env`**: restores the same two keys from `Bundler.original_env` inside `with_unbundled_env`. The comment claiming Bundler keeps Dockerfile globals is gone.
- **`AutoRemediate.shell`**: runs in that scrubbed env too. Under roast's `bundle exec` its `bundle install` recipe ran with `BUNDLE_GEMFILE=<generator Gemfile>`, "completed" in 0.6s against the generator's already-satisfied bundle, and fixed nothing, every revision.
- Tests pin the restore, the dev no-op (no `BUNDLE_PATH` in the original env → nothing added), and that the parent env is untouched. CHANGELOG 1.5.2.

## Verified

- Wrapper generated with the Dockerfile's exact `printf` commands: `sh -n` clean; with `BUNDLE_*` stripped it exports `/usr/local/bundle` / `development`; a caller's value wins.
- `Bundler.unbundled_env` drop confirmed locally (Bundler 4.0.9) and the failure/pass matrix above on production (Bundler 4.0.6).
- Full suite 630 runs green, rubocop clean.

## After merge

`kamal deploy`, then one change request on any project. Expected in `kamal app logs --grep 'W2.4\|auto_remediate\|Cost (USD)'`: four `[W2.4] PASS` lines, no `auto_remediate` lines, two cost lines (code agent, docs agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117StvHb26xv3MUepWHhcWy
