### PR TITLE
Ask about example data, offer to add more before building, and plan new apps in 4-8 revisions

### DIFF
--- a/app/prompts/generator_agent/instructions.txt.erb
+++ b/app/prompts/generator_agent/instructions.txt.erb
@@ -5,7 +5,7 @@ Two states matter for your behavior:
 A) THE USER IS DESCRIBING WORK YOU HAVEN'T STARTED YET.
    - Ask approximately 2 clarifying questions. Prefer reasonable defaults over interrogating.
    - If `create_application` is the tool offered (a brand-new application), ALWAYS also ask whether it should come pre-filled with example data. Ask this ON TOP OF the clarifying questions above — never in place of one. Never ask it when `modify_application` is the tool offered.
-   - When you understand the user's intent, **summarise it back in 1-2 sentences and ASK** ("Ready to start?" / "Should I apply this?"). Do NOT call `create_application` or `modify_application` yet.
+   - When you understand the user's intent, **summarise it back in 1-2 sentences and ASK** — for a brand-new application ("Ready to start building, or would you like to add anything else?"), for a change to an existing one ("Should I apply this?"). Do NOT call `create_application` or `modify_application` yet.
    - Only AFTER the user's NEXT message confirms ("yes", "go ahead", "do it", "proceed", or any clear affirmation), call `create_application` (for a brand-new project) OR `modify_application` (for a change to an existing app). Only ONE of these tools is bound at any time — use whichever is offered. When you make this tool call, the tool call is your entire response — do not write any prose alongside it.
    - Pass `intent:` as a plain-language description. Pass `clarifications:` as a hash of the specific answers you gathered; pass `{}` if there were none.
 

--- a/app/prompts/generator_agent/instructions.txt.erb
+++ b/app/prompts/generator_agent/instructions.txt.erb
@@ -3,7 +3,8 @@ You are an assistant helping the user describe a Rails web application they want
 Two states matter for your behavior:
 
 A) THE USER IS DESCRIBING WORK YOU HAVEN'T STARTED YET.
-   - Ask at most 2 clarifying questions. Prefer reasonable defaults over interrogating.
+   - Ask approximately 2 clarifying questions. Prefer reasonable defaults over interrogating.
+   - If `create_application` is the tool offered (a brand-new application), ALWAYS also ask whether it should come pre-filled with example data. Ask this ON TOP OF the clarifying questions above — never in place of one. Never ask it when `modify_application` is the tool offered.
    - When you understand the user's intent, **summarise it back in 1-2 sentences and ASK** ("Ready to start?" / "Should I apply this?"). Do NOT call `create_application` or `modify_application` yet.
    - Only AFTER the user's NEXT message confirms ("yes", "go ahead", "do it", "proceed", or any clear affirmation), call `create_application` (for a brand-new project) OR `modify_application` (for a change to an existing app). Only ONE of these tools is bound at any time — use whichever is offered. When you make this tool call, the tool call is your entire response — do not write any prose alongside it.
    - Pass `intent:` as a plain-language description. Pass `clarifications:` as a hash of the specific answers you gathered; pass `{}` if there were none.

--- a/app/prompts/plan_application_creation_system.md
+++ b/app/prompts/plan_application_creation_system.md
@@ -1,7 +1,7 @@
 You are a Rails application planner. Given a user's plain-language intent, emit a short implementation plan matching the required JSON schema.
 
 Rules for the plan:
-- 3 to 6 revisions.
+- 4 to 8 revisions.
 - Each revision is one atomic, testable change ("add Product model with name/price", not "set up the shop").
 - The workspace is a default Rails 8 app with Tailwind and Hotwire, on the default Gemfile. Do NOT include `rails new`. If the app needs sign-in, plan a revision that adds it — `has_secure_password` plus sessions is the Rails-native default.
 - Tests are Minitest under `test/`, the Rails default, run with `bin/rails test`: `test/models/<name>_test.rb`, `test/controllers/<name>_controller_test.rb`, `test/integration/<flow>_test.rb`, fixtures in `test/fixtures/`. The default test stack is complete — plan no additional testing gems, frameworks or coverage tools. Every revision that adds or changes behaviour names the Minitest file(s) it adds.

--- a/app/prompts/plan_application_creation_system.md
+++ b/app/prompts/plan_application_creation_system.md
@@ -1,7 +1,7 @@
 You are a Rails application planner. Given a user's plain-language intent, emit a short implementation plan matching the required JSON schema.
 
 Rules for the plan:
-- 4 to 8 revisions.
+- 4 to 8 revisions. PREFER THE SMALLEST NUMBER that covers the work — most apps are 4 or 5; reserve 8 for an app with several distinct features (e.g. sign-in plus two unrelated resources plus a dashboard). Never split one unit of work to reach a higher count: a model and its migration are ONE revision, a scaffold and its CRUD actions are ONE revision.
 - Each revision is one atomic, testable change ("add Product model with name/price", not "set up the shop").
 - The workspace is a default Rails 8 app with Tailwind and Hotwire, on the default Gemfile. Do NOT include `rails new`. If the app needs sign-in, plan a revision that adds it — `has_secure_password` plus sessions is the Rails-native default.
 - Tests are Minitest under `test/`, the Rails default, run with `bin/rails test`: `test/models/<name>_test.rb`, `test/controllers/<name>_controller_test.rb`, `test/integration/<flow>_test.rb`, fixtures in `test/fixtures/`. The default test stack is complete — plan no additional testing gems, frameworks or coverage tools. Every revision that adds or changes behaviour names the Minitest file(s) it adds.

--- a/app/schemas/plan_schema.rb
+++ b/app/schemas/plan_schema.rb
@@ -8,7 +8,7 @@ class PlanSchema < Schematist::Schema
          description: "One-sentence human description of the whole plan."
 
   array :revisions,
-        description: "Ordered list of 3 to 6 atomic revisions." do
+        description: "Ordered list of 4 to 8 atomic revisions." do
     object do
       string :summary, description: "Git-commit-style one-liner summarising this revision."
       string :prompt,  description: "Concrete, file-level instruction passed to the implementer agent."

--- a/test/jobs/chat_respond_job_test.rb
+++ b/test/jobs/chat_respond_job_test.rb
@@ -168,6 +168,16 @@ class ChatRespondJobTest < ActiveJob::TestCase
     assert_includes rendered, "Do NOT call `create_application` or `modify_application`"
   end
 
+  test "instructs the agent to ask about example data when creating a new application" do
+    rendered = rendered_agent_instructions
+
+    # Label-level, like the "Formatting:" assertion above: this guards that the
+    # rule is still shipped and still scoped to the creation path, not its
+    # exact phrasing, which gets tuned by hand.
+    assert_includes rendered, "example data"
+    assert_includes rendered, "`create_application` is the tool offered"
+  end
+
   test "registers a CreateApplication tool bound to the project before completing" do
     captured_tools = []
     spy_with_tools(captured_tools) do
@@ -310,6 +320,19 @@ class ChatRespondJobTest < ActiveJob::TestCase
     Chat.class_eval do
       alias_method :with_context, :_original_with_context if method_defined?(:_original_with_context)
     end
+  end
+
+  # One turn's worth of rendered agent instructions. The two tests above that
+  # assert on state injection keep their own inline spy — they also assert on
+  # how many times with_runtime_instructions was called, which this discards.
+  def rendered_agent_instructions
+    captured = []
+    spy_with_instructions(captured) do
+      stub_complete(chunks: [ "ok" ]) do
+        perform_enqueued_jobs { ChatRespondJob.perform_now(@user_message.id) }
+      end
+    end
+    captured.first.first.first
   end
 
   def spy_with_instructions(captured)

--- a/test/jobs/chat_respond_job_test.rb
+++ b/test/jobs/chat_respond_job_test.rb
@@ -178,6 +178,13 @@ class ChatRespondJobTest < ActiveJob::TestCase
     assert_includes rendered, "`create_application` is the tool offered"
   end
 
+  test "offers to add more before building, and keeps the apply wording for changes" do
+    rendered = rendered_agent_instructions
+
+    assert_includes rendered, "would you like to add anything else?"
+    assert_includes rendered, "Should I apply this?"
+  end
+
   test "registers a CreateApplication tool bound to the project before completing" do
     captured_tools = []
     spy_with_tools(captured_tools) do

--- a/test/schemas/plan_schema_test.rb
+++ b/test/schemas/plan_schema_test.rb
@@ -21,5 +21,11 @@ class PlanSchemaTest < ActiveSupport::TestCase
     revisions = doc.dig("properties", "revisions")
     assert_equal "array", revisions["type"]
     assert_equal %w[prompt summary], revisions.dig("items", "properties").keys.sort
+
+    # Must stay in step with app/prompts/plan_application_creation_system.md:4 --
+    # the model reads both, and a disagreement is a contradictory instruction.
+    # Neither bound is enforced: no min_items/max_items is passed, so this is
+    # the description text the model sees, not a schema constraint.
+    assert_equal "Ordered list of 4 to 8 atomic revisions.", revisions["description"]
   end
 end

--- a/test/services/plan_application_creation/ad_hoc_llm_test.rb
+++ b/test/services/plan_application_creation/ad_hoc_llm_test.rb
@@ -66,8 +66,16 @@ class PlanApplicationCreation::AdHocLLMTest < ActiveSupport::TestCase
     assert_includes prompt, "has_secure_password"
   end
 
-  test "system prompt asks for 4 to 8 revisions" do
-    assert_includes PlanApplicationCreation::AdHocLLM::SYSTEM_PROMPT, "4 to 8 revisions"
+  # The range alone reads as a target rather than a limit -- probed against the
+  # live planner, both "a todo list app" and a finance tracker came back at
+  # exactly 8, and the earlier "3 to 6" wording anchored on 6 the same way. The
+  # low-end directive is what counteracts it, so it is guarded alongside the
+  # numbers. Same shape as the modification prompt's "PREFER A SINGLE REVISION".
+  test "system prompt asks for 4 to 8 revisions and steers to the low end" do
+    prompt = PlanApplicationCreation::AdHocLLM::SYSTEM_PROMPT
+    assert_includes prompt, "4 to 8 revisions"
+    assert_includes prompt, "PREFER THE SMALLEST NUMBER"
+    assert_includes prompt, "Never split one unit of work"
   end
 
   test "system prompt pins tests to Minitest under test/ and closes the test stack" do

--- a/test/services/plan_application_creation/ad_hoc_llm_test.rb
+++ b/test/services/plan_application_creation/ad_hoc_llm_test.rb
@@ -66,6 +66,10 @@ class PlanApplicationCreation::AdHocLLMTest < ActiveSupport::TestCase
     assert_includes prompt, "has_secure_password"
   end
 
+  test "system prompt asks for 4 to 8 revisions" do
+    assert_includes PlanApplicationCreation::AdHocLLM::SYSTEM_PROMPT, "4 to 8 revisions"
+  end
+
   test "system prompt pins tests to Minitest under test/ and closes the test stack" do
     prompt = PlanApplicationCreation::AdHocLLM::SYSTEM_PROMPT
     assert_includes prompt, "Minitest under `test/`"


### PR DESCRIPTION
Three prose changes to the chat and planner prompts. No Ruby logic, no schema, no migration.

## What changes

**The chat asks about example data before a first build.** Most generated apps ship with an empty database, so the preview lands on blank index pages. The planner already knows how to write `db/seeds.rb` — nothing ever asked the user whether they wanted it. Confirmed end to end: answering yes produced a plan containing *"Seed database with example books and loans"*, with no planner-prompt change needed.

**The readiness ask offers a way out.** `"Ready to start?"` becomes `"Ready to start building, or would you like to add anything else?"` — the last cheap moment to catch a missing feature. Creation only; modifications keep `"Should I apply this?"`.

**New-app plans are 4-8 revisions, preferring the smallest that fits.** Widened from 3-6, then steered, because the model treats the upper bound as a target rather than a limit.

## Two things worth a reviewer's attention

**Scoping to the creation path is prose, not plumbing.** Sections A and B of `instructions.txt.erb` split on *whether a build is running*, not on whether an application exists — section A covers both tools. A flat bullet would therefore also fire on "make the banner green". Since A already establishes that exactly one of `create_application` / `modify_application` is bound, keying the new rules to the offered tool is enough; no ERB local or second template needed.

**"at most 2 clarifying questions" became "approximately 2".** Under the hard cap the model spent one of its two slots on the example-data question instead of adding a third — the opposite of the intent. The cap was an arbitrary number to begin with.

## Verification

Every prompt change was probed against the live LLM, not just asserted on.

Chat (`bin/generate respond` on scratch projects, since prompt wording can't be unit-tested for behaviour):

- Creation → two clarifying questions **plus** *"Also, would you like the app to come pre-filled with some example books and lending records…"*, then *"Ready to start building, or would you like to add anything else?"*
- Modification (Gemfile in workspace, so `ModifyApplication` binds) → neither the example-data question nor the "start building" wording; *"Should I apply this?"* intact.
- Confirmation gate intact — zero tool-call rows at the readiness turn.

Planner (`bin/inspect-plan-application-creation`), before and after the low-end directive:

| Intent | 4-8 alone | + directive |
|---|---|---|
| a todo list app | 8 | **5** |
| a recipe box, tagged by cuisine | — | **6** |
| personal finance tracker with expenses, budgets, dashboard | 8 | **8** |

Both padding cases disappeared: the todo plan now folds the migration into the model revision and CRUD into the scaffold revision, where before they were separate. The large intent still reaches 8, so the directive steers rather than caps.

`bin/rails test` 742 runs / 3435 assertions / 0 failures · `bin/rubocop` clean.

## Deliberately not done

- **No seeds rule in the planner prompts.** The clarification answer is the whole mechanism.
- **No `min_items`/`max_items` on `PlanSchema`.** They would emit real `minItems`/`maxItems`, turning an off-range plan into *"Could not generate a plan. Ask the user to rephrase."* — worse than a plan of three. The range stays a hint, as it always was; the new `plan_schema_test` assertion only keeps the two copies of it from drifting into a contradictory instruction.
- **Modification planner's 1-6 untouched** — deliberately divergent since the Bug A fix.
- **Feature invention left open.** The 8-revision finance plan adds scope the intent didn't ask for (category management, income tracking, filtering, export). That is a different problem from revision count.

## Notes

Wall time per generation rises with revision count — roughly 20-27 min at 8 revisions against the ~9 min three-revision runs on record. Nothing gates this at runtime; `WALL_TIME_BUDGET` lives inside the `E2E_GENERATE` test, which uses a pinned 3-revision fixture and does not move with this change.

Unrelated, found while running the suite: the local **test** database held a stale `ruby_llm_models` row (`anthropic/claude-sonnet-5`). A non-empty table suppresses RubyLLM's fallback to the gem's bundled `models.json`, so every chat-touching test errored with `ModelNotFoundError` on `anthropic/claude-haiku-4.5` — including files this branch never touches. `bin/rails db:test:prepare` clears it, but no fixture keeps that table empty, so it can recur.

Plan and research: `thoughts/shared/plans/2026-09-12/chat-example-data-question-and-plan-size.md`, `thoughts/shared/research/2026-09-12/seed-data-question-and-plan-size.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SW7desfNVvjcghfMuPHbT3
